### PR TITLE
fix: webtools-example missing output

### DIFF
--- a/packages/core/src/generatePreset.ts
+++ b/packages/core/src/generatePreset.ts
@@ -71,7 +71,7 @@ export default function generatePreset({
       //----------------- checking ------------------
       const webToolsRes = (
         await api.applyPlugins({
-          key: `addDoctor ${transformString(command)} Check`,
+          key: `addDoctor${transformString(command)}Check`,
           type: ApplyPluginsType.add,
           args: meta,
         })


### PR DESCRIPTION
## 问题现象：
运行 `webtools-example` 项目时没触发输出任何检测结果

## 预期情况：
运行该项目会输出各check是否通过和对应提示

## 问题原因：
`applyPlugins`  传入的配置项中字符串的key在之前重构过程中额外多了空格，导致返回的数据为空数组，进而导致后续输出等逻辑均未触发

## 修复方法：
暂时选择为去除空格，在考虑是否可以进一步封装和抽象来保证整个项目中key的保持统一
