### PR TITLE
feat: add web-tools check, checkRegistry

### DIFF
--- a/packages/web-tools/src/features/checkRegistry.ts
+++ b/packages/web-tools/src/features/checkRegistry.ts
@@ -1,0 +1,79 @@
+import { DoctorLevel } from "@doctors/core";
+import { IApi } from "../type";
+import { chalkByDoctorLevel } from "@doctors/utils";
+import { execCommand } from "@doctors/utils";
+
+const commonRegistryHosts = [
+  "registry.npmjs.org", // npm
+  "registry.yarnpkg.com", // yarn
+  "mirrors.cloud.tencent.com", // tencent
+  "r.cnpmjs.org", // cnpm
+  "registry.npmmirror.com", // taobao
+  "skimdb.npmjs.com", // npmMirror
+];
+
+const deprecatedRegistryHosts = [
+  "registry.npm.taobao.org", // taobao
+];
+
+async function getCurrentRegistry(packageManager: string) {
+  try {
+    const registry = await execCommand(`${packageManager} config get registry`);
+    return registry;
+  } catch (err) {
+    return undefined;
+  }
+}
+
+function getEachLevel(currentRegistry?: string): DoctorLevel {
+  let level = DoctorLevel.WARN;
+  if (!currentRegistry) {
+    return level;
+  }
+  deprecatedRegistryHosts.forEach((registry) => {
+    if (currentRegistry.includes(registry)) level = DoctorLevel.ERROR;
+  });
+  commonRegistryHosts.forEach((registry) => {
+    if (currentRegistry.includes(registry)) level = DoctorLevel.SUCCESS;
+  });
+  return level;
+}
+
+export default (api: IApi) => {
+  api.addDoctorWebToolsCheck(async () => {
+    const ruleLevel = (api.userConfig.tools?.nodeVersion ||
+      DoctorLevel.WARN) as DoctorLevel;
+
+    if (ruleLevel === DoctorLevel.OFF) return;
+    const registries = [
+      await getCurrentRegistry("npm"),
+      await getCurrentRegistry("yarn"),
+      await getCurrentRegistry("pnpm"),
+    ];
+    //  Array<string> = [npmRegistry, yarnRegistry, pnpmRegistry];
+
+    const eachLevel = registries.map((registry) => getEachLevel(registry));
+
+    let overallLevel = DoctorLevel.SUCCESS;
+    if (eachLevel.includes(DoctorLevel.ERROR)) {
+      overallLevel = DoctorLevel.ERROR;
+    } else if (eachLevel.includes(DoctorLevel.WARN)) {
+      overallLevel = DoctorLevel.WARN;
+    }
+
+    return {
+      label: "Package Manager Registry",
+      description: `Registry should be stable and recognized: \n\n${chalkByDoctorLevel(
+        eachLevel[0],
+        ` NPM Registry: ${registries[0]}`
+      )}\n${chalkByDoctorLevel(
+        eachLevel[1],
+        ` YARN Registry: ${registries[1]}`
+      )}\n${chalkByDoctorLevel(
+        eachLevel[2],
+        ` PNPM Registry: ${registries[2]}`
+      )}`,
+      doctorLevel: overallLevel,
+    };
+  });
+};

--- a/packages/web-tools/src/features/index.ts
+++ b/packages/web-tools/src/features/index.ts
@@ -3,4 +3,5 @@ export default [
   require.resolve("./checkChrome"),
   require.resolve("./checkDefaultBrowser"),
   require.resolve("./checkGitSshKeyPersistent"),
+  require.resolve("./checkRegistry"),
 ];


### PR DESCRIPTION
用于检测当前`npm` `yarn` `pnpm`下载源是否稳定。
这里判定稳定的标准是，1. 广泛使用的 2. 没有被标记为废弃

>如果没有安装`yarn` `pnpm`，那么下载源被判定为undefined且标记为WARN

```js
// 广泛使用的
const commonRegistryHosts = [
  "registry.npmjs.org", // npm
  "registry.yarnpkg.com", // yarn
  "mirrors.cloud.tencent.com", // tencent
  "r.cnpmjs.org", // cnpm
  "registry.npmmirror.com", // taobao
  "skimdb.npmjs.com", // npmMirror
];

// 废弃的
const deprecatedRegistryHosts = [
  "registry.npm.taobao.org", // taobao
];
```