### PR TITLE
fix: api.userConfig type overload

### DIFF
--- a/packages/create-doctor/templates/feature/src/type.ts.tpl
+++ b/packages/create-doctor/templates/feature/src/type.ts.tpl
@@ -19,4 +19,6 @@ export type IApi = DoctorApi & {
   };
 
   addDoctor{{{ commandCamelCased }}}CheckEnd: (fn: () => void) => void;
+} & {
+  userConfig: ConfigSchema;
 };

--- a/packages/npm-pkg/src/type.ts
+++ b/packages/npm-pkg/src/type.ts
@@ -20,6 +20,8 @@ export type IApi = DoctorApi &
     addDoctorNpmPkgCheckEnd: (
       fn: (meta: Meta) => DoctorMeta[] | DoctorMeta | undefined
     ) => void;
+  } & {
+    userConfig: ConfigSchema;
   };
 
 export interface ConfigSchema {

--- a/packages/npm-pkg/src/utils.ts
+++ b/packages/npm-pkg/src/utils.ts
@@ -1,10 +1,10 @@
-import { IApi } from "@doctors/core";
 import { globSync } from "glob";
 import path from "path";
 import fs from "fs";
 import lodash from "lodash";
 import sourceParser, { IDoctorSourceParseResult } from "./parser";
 import { DEFAULT_SOURCE_IGNORES } from "./constants";
+import { IApi } from "./type";
 
 export interface SourceFile {
   path?: string;
@@ -22,8 +22,8 @@ export function getSourceFiles(api: IApi) {
   let files: string[] = [];
   let compileFiles: string[] = [];
 
-  if (api.userConfig?.npmPkg?.compileFIles) {
-    compileFiles = Array.isArray(api.userConfig?.npmPkg?.compileFIles)
+  if (api.userConfig.npmPkg?.compileFiles) {
+    compileFiles = Array.isArray(api.userConfig?.npmPkg?.compileFiles)
       ? api.userConfig?.npmPkg?.compileFiles
       : [api.userConfig?.npmPkg?.compileFiles];
   }
@@ -48,7 +48,7 @@ export function getSourceFiles(api: IApi) {
 
   const sourceDirs = getSourceDirs(files);
 
-  const allFiles: string[] = sourceDirs.reduce<string[]>(
+  let allFiles: string[] = sourceDirs.reduce<string[]>(
     (ret: string[], dir: string) =>
       ret.concat(
         globSync(`${dir}/**/*.{ts,js}`, {
@@ -60,7 +60,9 @@ export function getSourceFiles(api: IApi) {
     []
   );
 
-  return Array.from(new Set(allFiles)) || [];
+  allFiles = [...new Set(allFiles)];
+
+  return allFiles;
 }
 
 export async function getFilesWithImports(api: IApi) {

--- a/packages/web-tools/src/type.ts
+++ b/packages/web-tools/src/type.ts
@@ -25,4 +25,7 @@ export interface DoctorLifeCycleApi {
   addDoctorWebToolsCheckEnd: (fn: () => Awaitable<void>) => void;
 }
 
-export type IApi = DoctorApi & DoctorLifeCycleApi;
+export type IApi = DoctorApi &
+  DoctorLifeCycleApi & {
+    userConfig: ConfigSchema;
+  };


### PR DESCRIPTION
CR1: 修复 `npm-pkg/utils.ts` 中 `IApi` 引用错误以及 `getSourceFiles(IApi)` 中 `compileFiles` 拼写错误。
CR2: 为 `npm-pkg` 中 `IApi` 重载 `userConfig` 的类型。